### PR TITLE
Fix Ollama compatibility issues

### DIFF
--- a/z_engineer.py
+++ b/z_engineer.py
@@ -1,6 +1,7 @@
 import requests
 import json
 import logging
+import re
 
 class ZEngineer:
     def __init__(self):
@@ -61,25 +62,28 @@ class ZEngineer:
         }
 
         payload = {
-            "model": model,
+            "model": model.strip(),
             "messages": [
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": input_prompt}
             ],
             "temperature": temperature,
-            "seed": seed,
+            "seed": seed % (2**31 - 1),
             "stream": False
         }
 
         try:
             print(f"Sending request to {endpoint} with model {model}...")
-            response = requests.post(endpoint, headers=headers, json=payload, timeout=60)
+            response = requests.post(endpoint, headers=headers, json=payload, timeout=300)
             response.raise_for_status()
             
             data = response.json()
             
             # OpenAI format usually: choices[0].message.content
             output_text = data['choices'][0]['message']['content']
+
+            # Strip <think>...</think> blocks from reasoning models
+            output_text = re.sub(r'<think>.*?</think>\s*', '', output_text, flags=re.DOTALL)
             
             print(f"Z-Engineer Response: {output_text[:100]}...")
             


### PR DESCRIPTION
## Summary
- **Seed overflow fix**: ComfyUI generates seeds up to `0xffffffffffffffff` which overflows Go's `int` type in Ollama's OpenAI-compatible endpoint, causing 400 errors. Clamps seed to 32-bit signed int range via modulo.
- **Model name whitespace**: Strips leading/trailing whitespace from model name to prevent "model is required" errors when users accidentally add a space.
- **Reasoning model support**: Strips `<think>...</think>` blocks from output for reasoning models like Qwen3 that include internal chain-of-thought in their response.
- **Timeout increase**: 60s → 300s to handle cold model loads (first request after model is loaded into VRAM).

## Test plan
- [x] Tested with Ollama + Qwen3-4b-Z-Image-Engineer-V4 (Q8_0 GGUF)
- [x] Verified seed overflow no longer causes 400 errors
- [x] Verified model name with leading space no longer fails
- [x] Verified `<think>` blocks are stripped from output
- [x] Verified timeout handles cold loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)